### PR TITLE
chore: silencing some errors, fixing some code issues

### DIFF
--- a/metaflow/client/cache/cache_action.py
+++ b/metaflow/client/cache/cache_action.py
@@ -9,8 +9,6 @@ class CacheServerInitFailed(Exception):
 
 def import_action_class_spec(action_spec):
     parts = action_spec.split('.')
-    package = '.'.join(action_spec.split('.')[:-1])
-    action_name = action_spec.split('.')[-1]
     return import_action_class('.'.join(parts[:-1]), parts[-1])
 
 def import_action_class(mod, cls):

--- a/metaflow/client/cache/cache_async_client.py
+++ b/metaflow/client/cache/cache_async_client.py
@@ -2,7 +2,7 @@ import time
 import asyncio
 from subprocess import PIPE
 
-from .cache_client import CacheClient, CacheServerUnreachable
+from .cache_client import CacheClient, CacheServerUnreachable, CacheClientTimeout
 
 WAIT_FREQUENCY = 0.2
 HEARTBEAT_FREQUENCY = 1

--- a/metaflow/client/cache/cache_async_client.py
+++ b/metaflow/client/cache/cache_async_client.py
@@ -16,7 +16,7 @@ class CacheAsyncClient(CacheClient):
         asyncio.create_task(self._heartbeat())
 
     async def check(self):
-        ret = await self.Check()
+        ret = await self.Check()  # pylint: disable=no-member
         await ret.wait()
         ret.get()
 

--- a/metaflow/client/cache/cache_client.py
+++ b/metaflow/client/cache/cache_client.py
@@ -15,6 +15,10 @@ class CacheServerUnreachable(Exception):
 class CacheClientTimeout(Exception):
     pass
 
+
+class CacheStreamCorrupted(Exception):
+    pass
+
 class CacheFuture(object):
 
     def __init__(self, keys, stream_key, client, action_cls, root):
@@ -189,7 +193,7 @@ class CacheClient(object):
         """
         raise NotImplementedError
 
-    def check():
+    def check(self):
         """
         Call and wait on the Check action to ensure that the server is
         running.

--- a/metaflow/client/cache/cache_server.py
+++ b/metaflow/client/cache/cache_server.py
@@ -88,9 +88,9 @@ class MessageReader(object):
                             try:
                                 yield json.loads(line)
                             except:
-                                raise
                                 uni = line.decode('utf-8', errors='replace')
                                 echo("WARNING: Corrupted message: %s" % uni)
+                                raise
                         else:
                             # return the last partial line back to the buffer
                             new_buf.write(line)
@@ -139,7 +139,7 @@ class Worker(object):
             }
             json.dump(request, f)
 
-        cmd, env = subprocess_cmd_and_env('cache_worker')
+        cmd, _ = subprocess_cmd_and_env('cache_worker')
         cmdline = cmd + [\
                    '--request-file', 'request.json',\
                    self.request['action']\

--- a/metaflow/client/cache/cache_store.py
+++ b/metaflow/client/cache/cache_store.py
@@ -185,7 +185,7 @@ class CacheStore(object):
                         f.close()
                         try:
                             os.symlink(dst, src)
-                        except Exception as ex:
+                        except OSError as ex:
                             # two actions may be streaming the same object
                             # simultaneously. We don't consider an existing
                             # symlink (errno 17) to be an error.

--- a/metaflow/client/cache/cache_store.py
+++ b/metaflow/client/cache/cache_store.py
@@ -79,7 +79,7 @@ class CacheStore(object):
 
     def _init_gc(self, root):
         objects = []
-        for dirr, dirs, files in os.walk(root):
+        for dirr, _, files in os.walk(root):
             for fname in files:
                 path = os.path.join(dirr, fname)
                 if os.path.islink(path):
@@ -122,7 +122,6 @@ class CacheStore(object):
 
         # 1) delete marked objects that are past their quarantine period
         limit = time.time() - quarantine
-        deleted = []
         for path in list(self.gc_queue):
             tstamp, size = self.gc_queue[path]
             if tstamp < limit:

--- a/metaflow/client/cache/cache_sync_client.py
+++ b/metaflow/client/cache/cache_sync_client.py
@@ -1,7 +1,7 @@
 import time
 from subprocess import Popen, PIPE
 
-from .cache_client import CacheClient, CacheServerUnreachable
+from .cache_client import CacheClient, CacheServerUnreachable, CacheClientTimeout
 
 WAIT_FREQUENCY = 0.2
 HEARTBEAT_FREQUENCY = 1
@@ -13,12 +13,12 @@ class CacheSyncClient(CacheClient):
         self._prev_heartbeat = 0
 
     def check(self):
-        ret = self.Check()
+        ret = self.Check()  # pylint: disable=no-member
         ret.wait()
         ret.get()
 
     def stop_server(self):
-        if self._isalive:
+        if self._is_alive:
             self._is_alive = False
             self._proc.terminate()
             self._proc.wait()


### PR DESCRIPTION
Some cleanup for the mfgui cache changes. This PR is only for tidying up some low hanging fruit, and does not attempt to solve the underlying problem with carrying exceptions from the worker process to the CacheFuture yet.

- removes unused variables, or marks them as disposable in for loops.
- silences some pylint no-member errors caused by the way cache action classes are bound to the cache client.
- fix some issues with exception handling.